### PR TITLE
Fixed some issues with browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ tlock-js uses [AGE](https://age-encryption.org/v1) to symmetrically encrypt a pa
 
 ## Prerequisites
 - Node 16+
+- a browser that supports bigint (which is most of them - [see here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) )
  
 ## Quickstart
 - install the dependencies by running `npm install`
 - run the tests with `npm test`
+- run the linter and fix the problems by running `npm run lint:fix`
 
+## API
 ### `timelockEncrypt` 
 This encrypts a payload that can only be decrypted when the `roundNumber` has been reached.  
 The time of this `roundNumber` depends on the genesis and round frequency of the network you connect to.
@@ -29,7 +32,15 @@ Given a `NetworkInfo` object, it calculates the approximate time the given `roun
 
 ## Possible issues
 - you may need a `fetch` polyfill on some versions of node, e.g. [isomorphic fetch](https://www.npmjs.com/package/isomorphic-fetch).  You can provide your own `DrandHttpClientOptions` to the `DrandHttpClient` if you don't want to use fetch, but it may be necessary to declare a fake `fetch` somewhere for compilation
-
+- vite users may need to set their build target to "es2020" with a config such as:
+ ```javascript
+export default {
+    build: { target: "es2020" },
+    optimizeDeps: {
+        esbuildOptions: { target: "es2020", supported: { bigint: true } },
+    },
+};
+```
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
   "name": "tlock-js",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "A library to encrypt data that can only be decrypted in the future using drand",
   "source": "src/index.ts",
-  "main": "dist/index.js",
   "module": "dist/module.js",
   "types": "dist/index.d.ts",
+  "targets": {
+    "default": {
+      "engines": {
+        "outputFormat": "global"
+      }
+    }
+  },
   "scripts": {
     "build": "parcel build",
     "build:ci": "npm run build && npm run lint && npm run check && npm run test",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer"
 import {defaultClientInfo, DrandClient, DrandHttpClient, roundForTime, timeForRound} from "./drand/drand-client"
 import {createTimelockEncrypter} from "./drand/timelock-encrypter"
 import {decryptAge, encryptAge} from "./age/age-encrypt-decrypt"
@@ -29,4 +30,4 @@ export async function timelockDecrypt(
     return await decryptAge(cipher, timelockDecrypter)
 }
 
-export {DrandHttpClient, defaultClientInfo, roundForTime, timeForRound}
+export {DrandHttpClient, defaultClientInfo, roundForTime, timeForRound, Buffer}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "esnext",
+    "module": "es2020",
+    "target": "es2020",
     "sourceMap": true,
     "outDir": "./dist/",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "es2020",
+    "module": "commonjs",
     "target": "es2020",
     "sourceMap": true,
     "outDir": "./dist/",


### PR DESCRIPTION
* export `Buffer` class so that downstream users don't have to pull in a polyfill
* rejigged parcel config so that the built module doesn't use require so that users who don't use a bundler can use it in-browser
* added some advisory text for users of vite.js