### PR TITLE
Reverted a change to output encoding that broke special chars

### DIFF
--- a/src/age/age-encrypt-decrypt.ts
+++ b/src/age/age-encrypt-decrypt.ts
@@ -79,5 +79,5 @@ export async function decryptAge(
     const hkdfKey = hkdf(sha256, fileKey, nonce, Buffer.from(hkdfBodyMessage, "utf8"), hkdfKeyLengthBytes)
 
     const plaintext = STREAM.open(cipherText, hkdfKey)
-    return Buffer.from(plaintext).toString("binary")
+    return Buffer.from(plaintext).toString("utf8")
 }

--- a/test/age/age-encrypt-decrypt.test.ts
+++ b/test/age/age-encrypt-decrypt.test.ts
@@ -75,5 +75,13 @@ describe("age", () => {
             const result = await decryptAge(ciphertext)
             expect(result).to.equal(bigPayload)
         })
+
+        it("should correctly encrypt and decrypt special characters", async () => {
+            const someFrench = "ça a marché"
+            const ciphertext = await encryptAge(Buffer.from(someFrench))
+            const result = await decryptAge(ciphertext)
+
+            expect(result).to.equal(someFrench)
+        })
     })
 })

--- a/test/drand/timelock-encrypter.test.ts
+++ b/test/drand/timelock-encrypter.test.ts
@@ -1,10 +1,9 @@
 import {expect} from "chai"
 import {createTimelockEncrypter} from "../../src/drand/timelock-encrypter"
-import {defaultClientInfo} from "../../src/drand/drand-client"
+import {defaultClientInfo} from "../../src"
 import {MockDrandClient, validBeacon} from "./mock-drand-client"
 
 describe("timelock encrypter", () => {
-
     it("should throw an error if created with the genesis round", () => {
         expect(() => createTimelockEncrypter(defaultClientInfo, new MockDrandClient(validBeacon), 0)).to.throw()
     })


### PR DESCRIPTION
the previous commit that added the binary encoding said it was necessary for correct enc/dec, but none of the tests failed when removed and I suspect it was added before we sorted the chunking issues